### PR TITLE
Rewrite of Formatters to make them generic

### DIFF
--- a/src/PFsLib/PFsExFatFormatter.h
+++ b/src/PFsLib/PFsExFatFormatter.h
@@ -48,7 +48,8 @@ class PFsExFatFormatter {
   bool format(PFsVolume &partVol, uint8_t* secBuf, print_t* pr);
 
  private:
-   bool writeMbr();
+ 
+  bool writeMbr();
   bool syncUpcase();
   bool writeUpcase(uint32_t sector);
   bool writeUpcaseByte(uint8_t b);
@@ -75,6 +76,8 @@ class PFsExFatFormatter {
   uint32_t sectorCount;
   uint8_t sectorsPerClusterShift;
   uint32_t m_relativeSectors;
+  uint32_t m_part_relativeSectors;
+  uint32_t m_bytesPerCluster;
   uint8_t m_part;
   char volName[32];
   

--- a/src/PFsLib/PfsFatFormatter.h
+++ b/src/PFsLib/PfsFatFormatter.h
@@ -67,6 +67,7 @@ class PFsFatFormatter {
   uint8_t m_partType;
   uint8_t m_sectorsPerCluster;
   uint8_t m_part;
+  uint32_t m_part_relativeSectors;
   char volName[32];
 };
 #endif  // FatFormatter_h


### PR DESCRIPTION
@KurtE 
These are the latest changes to FatFormatter and ExFatFormatter.  They are now what I would call generic so all that is needed is Sector Count and Relative Sectors which come from the MBR.  No longer reliant on volume configuration as we discussed on the thread