### PR TITLE
More Updates to PFsLIB

### DIFF
--- a/src/PFsLib/PFsExFatFormatter.cpp
+++ b/src/PFsLib/PFsExFatFormatter.cpp
@@ -24,6 +24,7 @@
  */
 #define DBG_FILE "PFsExFatFormatter.cpp"
 //#include "../common/DebugMacros.h"
+#include "PFsLib.h"
 #include "PFsExFatFormatter.h"
 
 //#define DBG_PRINT 1
@@ -49,7 +50,7 @@ const uint32_t ROOT_CLUSTER = 4;
 #endif  // PRINT_FORMAT_PROGRESS
 //------------------------------------------------------------------------------
 
-bool PFsExFatFormatter::format(PFsVolume &partVol, uint8_t* secBuf, print_t* pr) {
+bool PFsExFatFormatter::ExFatFormat(PFsVolume &partVol, uint8_t* secBuf, print_t* pr) {
 #if !PRINT_FORMAT_PROGRESS
 (void)pr;
 #endif  //  !PRINT_FORMAT_PROGRESS

--- a/src/PFsLib/PFsExFatFormatter.h
+++ b/src/PFsLib/PFsExFatFormatter.h
@@ -45,8 +45,8 @@ class PFsExFatFormatter {
    *
    * \return true for success or false for failure.
    */
-  bool format(PFsVolume &partVol, uint8_t* secBuf, print_t* pr);
-
+  bool ExFatFormat(PFsVolume &partVol, uint8_t* secBuf, print_t* pr);
+  
  private:
  
   bool writeMbr();

--- a/src/PFsLib/PFsFatFormatter.cpp
+++ b/src/PFsLib/PFsFatFormatter.cpp
@@ -55,7 +55,7 @@ const uint16_t FAT16_ROOT_SECTOR_COUNT =
 #define writeMsg(str) if (m_pr) m_pr->write(str)
 #endif  // PRINT_FORMAT_PROGRESS
 //------------------------------------------------------------------------------
-bool PFsFatFormatter::format(PFsVolume &partVol, uint8_t fat_type, uint8_t* secBuf, print_t* pr) {
+bool PFsFatFormatter::FatFormat(PFsVolume &partVol, uint8_t fat_type, uint8_t* secBuf, print_t* pr) {
   MbrSector_t mbr;
 
   bool rtn;

--- a/src/PFsLib/PFsFatFormatter.h
+++ b/src/PFsLib/PFsFatFormatter.h
@@ -44,7 +44,7 @@ class PFsFatFormatter {
    *
    * \return true for success or false for failure.
    */
-  bool format(PFsVolume &partVol, uint8_t fat_type, uint8_t* secBuf, print_t* pr);
+  bool FatFormat(PFsVolume &partVol, uint8_t fat_type, uint8_t* secBuf, print_t* pr);
   bool createFatPartition(BlockDevice* dev, uint8_t fat_type, uint32_t startSector, uint32_t sectorCount, uint8_t* secBuf, print_t* pr);
   void dump_hexbytes(const void *ptr, int len);
 

--- a/src/PFsLib/PFsLib.cpp
+++ b/src/PFsLib/PFsLib.cpp
@@ -26,9 +26,11 @@ void inline DBGPrintf(...) {};
 //uint8_t partVols_drive_index[10];
 
 //=============================================================================
-bool PFsLib::deletePartition(BlockDeviceInterface *blockDev, uint8_t part, print_t* pr) 
+bool PFsLib::deletePartition(BlockDeviceInterface *blockDev, uint8_t part, print_t* pr, Stream &Serialx) 
 {
   uint8_t  sectorBuffer[512];
+  
+  m_pr = pr;
 
   MbrSector_t* mbr = reinterpret_cast<MbrSector_t*>(sectorBuffer);
   if (!blockDev->readSector(0, sectorBuffer)) {
@@ -37,13 +39,15 @@ bool PFsLib::deletePartition(BlockDeviceInterface *blockDev, uint8_t part, print
   }
 
   if ((part < 1) || (part > 4)) {
-    Serial.printf("ERROR: Invalid Partition: %u, only 1-4 are valid\n", part);
+    m_pr->printf("ERROR: Invalid Partition: %u, only 1-4 are valid\n", part);
     return false;
   }
 
   writeMsg("Warning this will delete the partition are you sure, continue: Y? ");
   int ch;
-  while ((ch = Serial.read()) == -1) ;
+  
+  //..... TODO CIN for READ ......
+  while ((ch = Serialx.read()) == -1) ;
   if (ch != 'Y') {
     writeMsg("Canceled");
     return false;
@@ -80,7 +84,7 @@ void PFsLib::InitializeDrive(BlockDeviceInterface *dev, uint8_t fat_type, print_
   uint8_t  sectorBuffer[512];
 
   m_dev = dev;
-  
+  m_pr = pr;
   
   //TODO: have to see if this is still valid
   PFsVolume partVol;
@@ -113,7 +117,7 @@ void PFsLib::InitializeDrive(BlockDeviceInterface *dev, uint8_t fat_type, print_
 */
   uint32_t sectorCount = dev->sectorCount();
   
-  Serial.printf("sectorCount = %u, FatType: %x\n", sectorCount, fat_type);
+  m_pr->printf("sectorCount = %u, FatType: %x\n", sectorCount, fat_type);
   
   // Serial.printf("Blocks: %u Size: %u\n", msDrives[drive_index].msCapacity.Blocks, msDrives[drive_index].msCapacity.BlockSize);
   if ((fat_type == FAT_TYPE_EXFAT) && (sectorCount < 0X100000 )) fat_type = 0; // hack to handle later
@@ -133,7 +137,7 @@ void PFsLib::InitializeDrive(BlockDeviceInterface *dev, uint8_t fat_type, print_
 
   // Temporary until exfat is setup...
   if (fat_type == FAT_TYPE_EXFAT) {
-    Serial.println("TODO createPartition on ExFat");
+    m_pr->println("TODO createPartition on ExFat");
     return;
   } else {
     // Fat16/32
@@ -146,6 +150,175 @@ void PFsLib::InitializeDrive(BlockDeviceInterface *dev, uint8_t fat_type, print_
  
 }
 
+
+void PFsLib::formatter(PFsVolume &partVol, uint8_t fat_type, bool dump_drive, bool g_exfat_dump_changed_sectors, Stream &Serialx)
+{
+  uint8_t  sectorBuffer[512];
+
+  if (fat_type == 0) fat_type = partVol.fatType();
+
+  if (fat_type != FAT_TYPE_FAT12) {
+    // 
+    uint8_t buffer[512];
+    MbrSector_t *mbr = (MbrSector_t *)buffer;
+    if (!partVol.blockDevice()->readSector(0, buffer)) return;
+    MbrPart_t *pt = &mbr->part[partVol.part() - 1];
+
+    uint32_t sector = getLe32(pt->relativeSectors);
+
+    // I am going to read in 24 sectors for EXFat.. 
+    uint8_t *bpb_area = (uint8_t*)malloc(512*24); 
+    if (!bpb_area) {
+      Serialx.println("Unable to allocate dump memory");
+      return;
+    }
+    // Lets just read in the top 24 sectors;
+    uint8_t *sector_buffer = bpb_area;
+    for (uint32_t i = 0; i < 24; i++) {
+      partVol.blockDevice()->readSector(sector+i, sector_buffer);
+      sector_buffer += 512;
+    }
+
+    if (dump_drive) {
+      sector_buffer = bpb_area;
+      
+      for (uint32_t i = 0; i < 12; i++) {
+        Serialx.printf("\nSector %u(%u)\n", i, sector);
+        dump_hexbytes(sector_buffer, 512);
+        sector++;
+        sector_buffer += 512;
+      }
+      for (uint32_t i = 12; i < 24; i++) {
+        Serialx.printf("\nSector %u(%u)\n", i, sector);
+        compare_dump_hexbytes(sector_buffer, sector_buffer - (512*12), 512);
+        sector++;
+        sector_buffer += 512;
+      }
+
+    } else {  
+      if (fat_type != FAT_TYPE_EXFAT) {
+        FatFormat(partVol, fat_type, sectorBuffer, &Serialx);
+      } else {
+        Serialx.println("ExFatFormatter - WIP");
+        ExFatFormat(partVol, sectorBuffer, &Serial);
+        if (g_exfat_dump_changed_sectors) {
+          // Now lets see what changed
+          uint8_t *sector_buffer = bpb_area;
+          for (uint32_t i = 0; i < 24; i++) {
+            partVol.blockDevice()->readSector(sector, buffer);
+            Serialx.printf("Sector %u(%u)\n", i, sector);
+            if (memcmp(buffer, sector_buffer, 512)) {
+              compare_dump_hexbytes(buffer, sector_buffer, 512);
+              Serialx.println();
+            }
+            sector++;
+            sector_buffer += 512;
+          }
+        }
+      }
+    }
+    free(bpb_area); 
+  }
+  else
+    Serialx.println("Cannot format an invalid partition");
+}
+
+
+
+
+//================================================================================================
+void PFsLib::print_partion_info(PFsVolume &partVol, Stream &Serialx) 
+{
+  uint8_t buffer[512];
+  MbrSector_t *mbr = (MbrSector_t *)buffer;
+  if (!partVol.blockDevice()->readSector(0, buffer)) return;
+  MbrPart_t *pt = &mbr->part[partVol.part() - 1];
+
+  uint32_t starting_sector = getLe32(pt->relativeSectors);
+  uint32_t sector_count = getLe32(pt->totalSectors);
+  Serialx.printf("Starting Sector: %u, Sector Count: %u\n", starting_sector, sector_count);    
+
+  FatPartition *pfp = partVol.getFatVol();
+  if (pfp) {
+    Serialx.printf("fatType:%u\n", pfp->fatType());
+    Serialx.printf("bytesPerClusterShift:%u\n", pfp->bytesPerClusterShift());
+    Serialx.printf("bytesPerCluster:%u\n", pfp->bytesPerCluster());
+    Serialx.printf("bytesPerSector:%u\n", pfp->bytesPerSector());
+    Serialx.printf("bytesPerSectorShift:%u\n", pfp->bytesPerSectorShift());
+    Serialx.printf("sectorMask:%u\n", pfp->sectorMask());
+    Serialx.printf("sectorsPerCluster:%u\n", pfp->sectorsPerCluster());
+    Serialx.printf("sectorsPerFat:%u\n", pfp->sectorsPerFat());
+    Serialx.printf("clusterCount:%u\n", pfp->clusterCount());
+    Serialx.printf("dataStartSector:%u\n", pfp->dataStartSector());
+    Serialx.printf("fatStartSector:%u\n", pfp->fatStartSector());
+    Serialx.printf("rootDirEntryCount:%u\n", pfp->rootDirEntryCount());
+    Serialx.printf("rootDirStart:%u\n", pfp->rootDirStart());
+  }
+} 
+
+
+uint32_t PFsLib::mbrDmp(BlockDeviceInterface *blockDev, uint32_t device_sector_count, Stream &Serialx) {
+  MbrSector_t mbr;
+  uint32_t next_free_sector = 8192;  // Some inital value this is default for Win32 on SD...
+  // bool valid = true;
+  if (!blockDev->readSector(0, (uint8_t*)&mbr)) {
+    Serialx.print("\nread MBR failed.\n");
+    //errorPrint();
+    return (uint32_t)-1;
+  }
+  Serialx.print("\nmsc # Partition Table\n");
+  Serialx.print("\tpart,boot,bgnCHS[3],type,endCHS[3],start,length\n");
+  for (uint8_t ip = 1; ip < 5; ip++) {
+    MbrPart_t *pt = &mbr.part[ip - 1];
+    uint32_t starting_sector = getLe32(pt->relativeSectors);
+    uint32_t total_sector = getLe32(pt->totalSectors);
+    if (starting_sector > next_free_sector) {
+      Serialx.printf("\t < unused area starting at: %u length %u >\n", next_free_sector, starting_sector-next_free_sector);
+    }
+    switch (pt->type) {
+    case 4:
+    case 6:
+    case 0xe:
+      Serial.print("FAT16:\t");
+      break;
+    case 11:
+    case 12:
+      Serial.print("FAT32:\t");
+      break;
+    case 7:
+      Serial.print("exFAT:\t");
+      break;
+    case 0xf:
+      Serial.print("Extend:\t");
+      break;
+    case 0x83: Serial.print("ext2/3/4:\t"); break; 
+    default:
+      Serialx.print("pt_#");
+      Serialx.print(pt->type);
+      Serialx.print(":\t");
+      break;
+    }
+    Serialx.print( int(ip)); Serial.print( ',');
+    Serialx.print(int(pt->boot), HEX); Serial.print( ',');
+    for (int i = 0; i < 3; i++ ) {
+      Serialx.print("0x"); Serial.print(int(pt->beginCHS[i]), HEX); Serial.print( ',');
+    }
+    Serialx.print("0x"); Serial.print(int(pt->type), HEX); Serial.print( ',');
+    for (int i = 0; i < 3; i++ ) {
+      Serialx.print("0x"); Serial.print(int(pt->endCHS[i]), HEX); Serial.print( ',');
+    }
+    Serialx.print(starting_sector, DEC); Serial.print(',');
+    Serialx.println(total_sector);
+
+    // Lets get the max of start+total
+    if (starting_sector && total_sector)  next_free_sector = starting_sector + total_sector;
+  }
+  if ((device_sector_count != (uint32_t)-1) && (next_free_sector < device_sector_count)) {
+    Serialx.printf("\t < unused area starting at: %u length %u >\n", next_free_sector, device_sector_count-next_free_sector);
+  } 
+  return next_free_sector;
+}
+
 //----------------------------------------------------------------
 
 void PFsLib::dump_hexbytes(const void *ptr, int len)
@@ -155,7 +328,27 @@ void PFsLib::dump_hexbytes(const void *ptr, int len)
   while (len) {
     for (uint8_t i = 0; i < 32; i++) {
       if (i > len) break;
-      Serial.printf("%02X ", p[i]);
+      m_pr->printf("%02X ", p[i]);
+    }
+    m_pr->print(":");
+    for (uint8_t i = 0; i < 32; i++) {
+      if (i > len) break;
+      m_pr->printf("%c", ((p[i] >= ' ') && (p[i] <= '~')) ? p[i] : '.');
+    }
+    m_pr->println();
+    p += 32;
+    len -= 32;
+  }
+}
+
+void PFsLib::compare_dump_hexbytes(const void *ptr, const uint8_t *compare_buf, int len)
+{
+  if (ptr == NULL || len <= 0) return;
+  const uint8_t *p = (const uint8_t *)ptr;
+  while (len) {
+    for (uint8_t i = 0; i < 32; i++) {
+      if (i > len) break;
+      Serial.printf("%c%02X", (p[i]==compare_buf[i])? ' ' : '*',p[i]);
     }
     Serial.print(":");
     for (uint8_t i = 0; i < 32; i++) {
@@ -164,6 +357,7 @@ void PFsLib::dump_hexbytes(const void *ptr, int len)
     }
     Serial.println();
     p += 32;
+    compare_buf += 32;
     len -= 32;
   }
 }

--- a/src/PFsLib/PFsLib.h
+++ b/src/PFsLib/PFsLib.h
@@ -36,13 +36,17 @@
 class PFsLib : public PFsFatFormatter, PFsExFatFormatter
 {
  public:
-	bool deletePartition(BlockDeviceInterface *blockDev, uint8_t part, print_t* pr); 
+	bool deletePartition(BlockDeviceInterface *blockDev, uint8_t part, print_t* pr, Stream &Serialx); 
 	void InitializeDrive(BlockDeviceInterface *dev, uint8_t fat_type, print_t* pr);
- void dump_hexbytes(const void *ptr, int len);
+	void formatter(PFsVolume &partVol, uint8_t fat_type, bool dump_drive, bool g_exfat_dump_changed_sectors, Stream &Serialx);
+	void dump_hexbytes(const void *ptr, int len);
+	void print_partion_info(PFsVolume &partVol, Stream &Serialx);
+	uint32_t mbrDmp(BlockDeviceInterface *blockDev, uint32_t device_sector_count, Stream &Serialx);
+	void compare_dump_hexbytes(const void *ptr, const uint8_t *compare_buf, int len);
+
  private:
 	BlockDevice* m_dev;
 	print_t*m_pr;
-	
 
 };
  


### PR DESCRIPTION
@KurtE  -  moved several more functions to PFsLib:
formatter
mbrDmp
print_partion_info
and
compare_dump_hexbytes

At some point guess we can clean up the dumps.   Oh, one more thing passed in with Serial I want to print to :)  besides the print pointer.  So all the prints and reads are general.  Think have to go back through and straighten out whether I want to use m_pr or Serialx.

The sketch is definitely cleaner.

Cheers - have fun.