### PR TITLE
Reverted back to using format instead of FatFormat ....

### DIFF
--- a/src/PFsLib/PFsExFatFormatter.cpp
+++ b/src/PFsLib/PFsExFatFormatter.cpp
@@ -50,7 +50,7 @@ const uint32_t ROOT_CLUSTER = 4;
 #endif  // PRINT_FORMAT_PROGRESS
 //------------------------------------------------------------------------------
 
-bool PFsExFatFormatter::ExFatFormat(PFsVolume &partVol, uint8_t* secBuf, print_t* pr) {
+bool PFsExFatFormatter::format(PFsVolume &partVol, uint8_t* secBuf, print_t* pr) {
 #if !PRINT_FORMAT_PROGRESS
 (void)pr;
 #endif  //  !PRINT_FORMAT_PROGRESS

--- a/src/PFsLib/PFsExFatFormatter.h
+++ b/src/PFsLib/PFsExFatFormatter.h
@@ -45,7 +45,7 @@ class PFsExFatFormatter {
    *
    * \return true for success or false for failure.
    */
-  bool ExFatFormat(PFsVolume &partVol, uint8_t* secBuf, print_t* pr);
+  bool format(PFsVolume &partVol, uint8_t* secBuf, print_t* pr);
   
  private:
  

--- a/src/PFsLib/PFsFatFormatter.cpp
+++ b/src/PFsLib/PFsFatFormatter.cpp
@@ -55,7 +55,7 @@ const uint16_t FAT16_ROOT_SECTOR_COUNT =
 #define writeMsg(str) if (m_pr) m_pr->write(str)
 #endif  // PRINT_FORMAT_PROGRESS
 //------------------------------------------------------------------------------
-bool PFsFatFormatter::FatFormat(PFsVolume &partVol, uint8_t fat_type, uint8_t* secBuf, print_t* pr) {
+bool PFsFatFormatter::format(PFsVolume &partVol, uint8_t fat_type, uint8_t* secBuf, print_t* pr) {
   MbrSector_t mbr;
 
   bool rtn;

--- a/src/PFsLib/PFsFatFormatter.h
+++ b/src/PFsLib/PFsFatFormatter.h
@@ -44,7 +44,7 @@ class PFsFatFormatter {
    *
    * \return true for success or false for failure.
    */
-  bool FatFormat(PFsVolume &partVol, uint8_t fat_type, uint8_t* secBuf, print_t* pr);
+  bool format(PFsVolume &partVol, uint8_t fat_type, uint8_t* secBuf, print_t* pr);
   bool createFatPartition(BlockDevice* dev, uint8_t fat_type, uint32_t startSector, uint32_t sectorCount, uint8_t* secBuf, print_t* pr);
   void dump_hexbytes(const void *ptr, int len);
 


### PR DESCRIPTION
@KurtE 
On last update I changed names of format(... to FatFormat and ExFatFormat.  I slept on it and put it back to format and fixed the calls by doing PFsFatFormatter::format etc.   Figured it wouldn't impact anything else - at least the name.